### PR TITLE
Update EntryType.cs

### DIFF
--- a/GoogleCloudPrintApi/Models/Share/EntryType.cs
+++ b/GoogleCloudPrintApi/Models/Share/EntryType.cs
@@ -8,6 +8,7 @@ namespace GoogleCloudPrintApi.Models.Share
     {
         USER,
         GROUP,
-        DOMAIN
+        DOMAIN,
+        PUBLIC
     }
 }


### PR DESCRIPTION
The "Save to Google Drive" printer uses the "PUBLIC" EntryType.